### PR TITLE
feat(logs): implement logview and logadd commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -188,11 +188,19 @@ $teamspeak->messages()->sendToServer();
 
 ## logview
 
-Not implemented.
+```php
+$teamspeak->logs()->list();
+// with options:
+$teamspeak->logs()->list(lines: 50, reverse: true, instance: true, beginPos: 100);
+```
 
 ## logadd
 
-Not implemented.
+```php
+use TeamSpeak\WebQuery\Enums\LogLevel;
+
+$teamspeak->logs()->add(LogLevel::Info, 'custom log message');
+```
 
 ## gm
 

--- a/src/Contracts/Resources/LogsContract.php
+++ b/src/Contracts/Resources/LogsContract.php
@@ -4,4 +4,18 @@ declare(strict_types=1);
 
 namespace TeamSpeak\WebQuery\Contracts\Resources;
 
-interface LogsContract {}
+use TeamSpeak\WebQuery\Enums\LogLevel;
+use TeamSpeak\WebQuery\Responses\Logs\ListResponse;
+
+interface LogsContract
+{
+    /**
+     * Displays a specified number of entries from the server log.
+     */
+    public function list(?int $lines = null, bool $reverse = false, bool $instance = false, ?int $beginPos = null): ListResponse;
+
+    /**
+     * Writes a custom entry into the server log.
+     */
+    public function add(LogLevel $level, string $message): void;
+}

--- a/src/Resources/Logs.php
+++ b/src/Resources/Logs.php
@@ -5,8 +5,41 @@ declare(strict_types=1);
 namespace TeamSpeak\WebQuery\Resources;
 
 use TeamSpeak\WebQuery\Contracts\Resources\LogsContract;
+use TeamSpeak\WebQuery\Enums\LogLevel;
+use TeamSpeak\WebQuery\Enums\Query\Command;
+use TeamSpeak\WebQuery\Responses\Logs\ListResponse;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Payload;
 
 final class Logs implements LogsContract
 {
     use Concerns\Transportable;
+
+    /**
+     * Displays a specified number of entries from the server log.
+     */
+    public function list(?int $lines = null, bool $reverse = false, bool $instance = false, ?int $beginPos = null): ListResponse
+    {
+        $payload = new Payload(
+            command: Command::LogView,
+            parameters: ['lines' => $lines, 'reverse' => $reverse ? 1 : null, 'instance' => $instance ? 1 : null, 'begin_pos' => $beginPos],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<list<array{l: string}>> $response */
+        $response = $this->transporter->request($payload);
+
+        return ListResponse::from($response->body());
+    }
+
+    /**
+     * Writes a custom entry into the server log.
+     */
+    public function add(LogLevel $level, string $message): void
+    {
+        $payload = new Payload(
+            command: Command::LogAdd,
+            parameters: ['loglevel' => $level->value, 'logmsg' => $message],
+        );
+
+        $this->transporter->request($payload);
+    }
 }

--- a/src/Responses/Logs/ListResponse.php
+++ b/src/Responses/Logs/ListResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Logs;
+
+final class ListResponse
+{
+    /**
+     * @param  list<ListResponseLog>  $logs
+     */
+    private function __construct(public array $logs) {}
+
+    /**
+     * @param  list<array{l: string}>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            array_map(ListResponseLog::from(...), $attributes)
+        );
+    }
+}

--- a/src/Responses/Logs/ListResponseLog.php
+++ b/src/Responses/Logs/ListResponseLog.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Logs;
+
+use DateTimeImmutable;
+use TeamSpeak\WebQuery\Enums\LogLevel;
+
+final class ListResponseLog
+{
+    private function __construct(
+        public DateTimeImmutable $timestamp,
+        public LogLevel $level,
+        public string $channel,
+        public int $serverId,
+        public string $message,
+    ) {}
+
+    /**
+     * @param  array{l: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $parts = explode('|', $attributes['l'], 5);
+
+        $level = match (mb_trim($parts[1])) {
+            'ERROR' => LogLevel::Error,
+            'WARNING' => LogLevel::Warning,
+            'DEBUG' => LogLevel::Debug,
+            default => LogLevel::Info,
+        };
+
+        return new self(
+            DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', mb_trim($parts[0])) ?: new DateTimeImmutable(),
+            $level,
+            mb_trim($parts[2]),
+            (int) mb_trim($parts[3]),
+            mb_trim($parts[4] ?? ''),
+        );
+    }
+}

--- a/tests/Unit/Resources/LogsTest.php
+++ b/tests/Unit/Resources/LogsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use TeamSpeak\WebQuery\Enums\LogLevel;
+use TeamSpeak\WebQuery\Resources\Logs;
+use TeamSpeak\WebQuery\Transporters\HttpTransporter;
+use TeamSpeak\WebQuery\ValueObjects\ApiKey;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\BaseUri;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Headers;
+
+beforeEach(function () {
+    $this->client = Mockery::mock(ClientInterface::class);
+
+    $apiKey = ApiKey::from('foo');
+
+    $this->http = new HttpTransporter(
+        $this->client,
+        BaseUri::from('teamspeak.com'),
+        Headers::withXApiKey($apiKey),
+    );
+});
+
+test('list', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'l' => '2024-06-22 20:03:05.123456|INFO    |VirtualServer |1  |client connected',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect($resource->list()->logs)->toBeArray()->toHaveCount(1);
+});
+
+test('list with options', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'l' => '2024-06-22 20:03:05.123456|INFO    |VirtualServer |1  |client connected',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['lines' => '50', 'reverse' => '1', 'instance' => '1', 'begin_pos' => '100']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->list(lines: 50, reverse: true, instance: true, beginPos: 100);
+});
+
+test('list with default parameters sends empty body', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBe('');
+
+            return true;
+        })->andReturn($response);
+
+    $resource->list();
+});
+
+test('add', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['loglevel' => '4', 'logmsg' => 'test message']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->add(LogLevel::Info, 'test message');
+})->doesNotPerformAssertions();

--- a/tests/Unit/Responses/Logs/ListResponseLogTest.php
+++ b/tests/Unit/Responses/Logs/ListResponseLogTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Enums\LogLevel;
+use TeamSpeak\WebQuery\Responses\Logs\ListResponseLog;
+
+test('from info', function () {
+    $log = ListResponseLog::from([
+        'l' => '2024-06-22 20:03:05.123456|INFO    |VirtualServer |1  |client connected',
+    ]);
+
+    expect($log->timestamp)->toBeInstanceOf(DateTimeImmutable::class)
+        ->and($log->level)->toBe(LogLevel::Info)
+        ->and($log->channel)->toBe('VirtualServer')
+        ->and($log->serverId)->toBe(1)
+        ->and($log->message)->toBe('client connected');
+});
+
+test('from warning', function () {
+    $log = ListResponseLog::from([
+        'l' => '2024-06-22 20:03:05.000000|WARNING |Query         |0  |something suspicious',
+    ]);
+
+    expect($log->level)->toBe(LogLevel::Warning)
+        ->and($log->channel)->toBe('Query')
+        ->and($log->serverId)->toBe(0)
+        ->and($log->message)->toBe('something suspicious');
+});
+
+test('from error', function () {
+    $log = ListResponseLog::from([
+        'l' => '2024-06-22 20:03:05.000000|ERROR   |VirtualServer |2  |something failed',
+    ]);
+
+    expect($log->level)->toBe(LogLevel::Error)
+        ->and($log->serverId)->toBe(2)
+        ->and($log->message)->toBe('something failed');
+});
+
+test('from debug', function () {
+    $log = ListResponseLog::from([
+        'l' => '2024-06-22 20:03:05.000000|DEBUG   |VirtualServer |1  |debug message',
+    ]);
+
+    expect($log->level)->toBe(LogLevel::Debug)
+        ->and($log->message)->toBe('debug message');
+});

--- a/tests/Unit/Responses/Logs/ListResponseTest.php
+++ b/tests/Unit/Responses/Logs/ListResponseTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Logs\ListResponse;
+use TeamSpeak\WebQuery\Responses\Logs\ListResponseLog;
+
+test('from', function () {
+    $response = ListResponse::from([[
+        'l' => '2024-06-22 20:03:05.123456|INFO    |VirtualServer |1  |client connected',
+    ]]);
+
+    expect($response->logs)->toBeArray()->toHaveCount(1)
+        ->and($response->logs[0])->toBeInstanceOf(ListResponseLog::class);
+});


### PR DESCRIPTION
## Summary

- Implements `logview` and `logadd` commands (closes #10)
- Adds `ListResponseLog` DTO parsing TS3 pipe-delimited log lines into typed fields: `timestamp` (`DateTimeImmutable`), `level` (`LogLevel` enum), `channel`, `serverId`, `message`
- Adds `ListResponse` collection wrapper
- Fills out `LogsContract` interface and `Logs` resource class
- Updates `COMMANDS.md` with PHP usage examples

## Test plan

- [ ] `composer test` passes (188 tests, 100% code + type coverage)
- [ ] `list()` with and without options (lines, reverse, instance, beginPos)
- [ ] `add()` request body verified
- [ ] Log line parsing tested for INFO, WARNING, ERROR, DEBUG levels

Generated with [Claude Code](https://claude.com/claude-code)