### PR TITLE
feat(whoami): implement whoami command

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -672,4 +672,6 @@ Not implemented.
 
 ## whoami
 
-Not implemented.
+```php
+$teamspeak->whoami();
+```

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ namespace TeamSpeak\WebQuery;
 
 use TeamSpeak\WebQuery\Contracts\ClientContract;
 use TeamSpeak\WebQuery\Contracts\TransporterContract;
+use TeamSpeak\WebQuery\Enums\Query\Command;
 use TeamSpeak\WebQuery\Resources\Bans;
 use TeamSpeak\WebQuery\Resources\ChannelGroups;
 use TeamSpeak\WebQuery\Resources\ChannelPermissions;
@@ -21,6 +22,8 @@ use TeamSpeak\WebQuery\Resources\PrivilegeKeys;
 use TeamSpeak\WebQuery\Resources\ServerGroups;
 use TeamSpeak\WebQuery\Resources\Servers;
 use TeamSpeak\WebQuery\Resources\Tokens;
+use TeamSpeak\WebQuery\Responses\WhoAmI\WhoAmIResponse;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Payload;
 
 final readonly class Client implements ClientContract
 {
@@ -144,5 +147,18 @@ final readonly class Client implements ClientContract
     public function tokens(): Tokens
     {
         return new Tokens($this->transporter);
+    }
+
+    /**
+     * Returns information about the current query client session.
+     */
+    public function whoami(): WhoAmIResponse
+    {
+        $payload = new Payload(Command::WhoAmI);
+
+        /** @var ValueObjects\Transporter\Response<array{0: array{client_channel_id: string, client_database_id: string, client_id: string, client_login_name: string, client_nickname: string, client_origin_server_id: string, client_unique_identifier: string, virtualserver_id: string, virtualserver_port: string, virtualserver_status: string, virtualserver_unique_identifier: string}}> $response */
+        $response = $this->transporter->request($payload);
+
+        return WhoAmIResponse::from($response->body());
     }
 }

--- a/src/Contracts/ClientContract.php
+++ b/src/Contracts/ClientContract.php
@@ -19,6 +19,7 @@ use TeamSpeak\WebQuery\Contracts\Resources\PrivilegeKeysContract;
 use TeamSpeak\WebQuery\Contracts\Resources\ServerGroupsContract;
 use TeamSpeak\WebQuery\Contracts\Resources\ServersContract;
 use TeamSpeak\WebQuery\Contracts\Resources\TokensContract;
+use TeamSpeak\WebQuery\Responses\WhoAmI\WhoAmIResponse;
 
 interface ClientContract
 {
@@ -96,4 +97,9 @@ interface ClientContract
      * Interact with the tokens.
      */
     public function tokens(): TokensContract;
+
+    /**
+     * Returns information about the current query client session.
+     */
+    public function whoami(): WhoAmIResponse;
 }

--- a/src/Responses/WhoAmI/WhoAmIResponse.php
+++ b/src/Responses/WhoAmI/WhoAmIResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\WhoAmI;
+
+final readonly class WhoAmIResponse
+{
+    private function __construct(
+        public int $clientChannelId,
+        public int $clientDatabaseId,
+        public int $clientId,
+        public string $clientLoginName,
+        public string $clientNickname,
+        public int $clientOriginServerId,
+        public string $clientUniqueIdentifier,
+        public int $virtualServerId,
+        public int $virtualServerPort,
+        public string $virtualServerStatus,
+        public string $virtualServerUniqueIdentifier,
+    ) {}
+
+    /**
+     * @param  array{0: array{client_channel_id: string, client_database_id: string, client_id: string, client_login_name: string, client_nickname: string, client_origin_server_id: string, client_unique_identifier: string, virtualserver_id: string, virtualserver_port: string, virtualserver_status: string, virtualserver_unique_identifier: string}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes[0]['client_channel_id'],
+            (int) $attributes[0]['client_database_id'],
+            (int) $attributes[0]['client_id'],
+            $attributes[0]['client_login_name'],
+            $attributes[0]['client_nickname'],
+            (int) $attributes[0]['client_origin_server_id'],
+            $attributes[0]['client_unique_identifier'],
+            (int) $attributes[0]['virtualserver_id'],
+            (int) $attributes[0]['virtualserver_port'],
+            $attributes[0]['virtualserver_status'],
+            $attributes[0]['virtualserver_unique_identifier'],
+        );
+    }
+}

--- a/tests/Unit/Responses/WhoAmI/WhoAmIResponseTest.php
+++ b/tests/Unit/Responses/WhoAmI/WhoAmIResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\WhoAmI\WhoAmIResponse;
+
+test('from', function () {
+    $response = WhoAmIResponse::from([[
+        'client_channel_id' => '1',
+        'client_database_id' => '1',
+        'client_id' => '14',
+        'client_login_name' => '<internal>',
+        'client_nickname' => 'serveradmin',
+        'client_origin_server_id' => '0',
+        'client_unique_identifier' => 'serveradmin',
+        'virtualserver_id' => '1',
+        'virtualserver_port' => '9987',
+        'virtualserver_status' => 'online',
+        'virtualserver_unique_identifier' => 'dwcJxlwg51mhDP1nlVQh51sIIzo=',
+    ]]);
+
+    expect($response->clientChannelId)->toBe(1)
+        ->and($response->clientDatabaseId)->toBe(1)
+        ->and($response->clientId)->toBe(14)
+        ->and($response->clientLoginName)->toBe('<internal>')
+        ->and($response->clientNickname)->toBe('serveradmin')
+        ->and($response->clientOriginServerId)->toBe(0)
+        ->and($response->clientUniqueIdentifier)->toBe('serveradmin')
+        ->and($response->virtualServerId)->toBe(1)
+        ->and($response->virtualServerPort)->toBe(9987)
+        ->and($response->virtualServerStatus)->toBe('online')
+        ->and($response->virtualServerUniqueIdentifier)->toBe('dwcJxlwg51mhDP1nlVQh51sIIzo=');
+});

--- a/tests/Unit/WhoAmITest.php
+++ b/tests/Unit/WhoAmITest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use TeamSpeak\WebQuery\Client;
+use TeamSpeak\WebQuery\Responses\WhoAmI\WhoAmIResponse;
+use TeamSpeak\WebQuery\Transporters\HttpTransporter;
+use TeamSpeak\WebQuery\ValueObjects\ApiKey;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\BaseUri;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Headers;
+
+beforeEach(function () {
+    $this->httpClient = Mockery::mock(ClientInterface::class);
+
+    $apiKey = ApiKey::from('foo');
+
+    $http = new HttpTransporter(
+        $this->httpClient,
+        BaseUri::from('teamspeak.com'),
+        Headers::withXApiKey($apiKey),
+    );
+
+    $this->client = new Client($http);
+});
+
+test('whoami', function () {
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'client_channel_id' => '1',
+            'client_database_id' => '1',
+            'client_id' => '14',
+            'client_login_name' => '<internal>',
+            'client_nickname' => 'serveradmin',
+            'client_origin_server_id' => '0',
+            'client_unique_identifier' => 'serveradmin',
+            'virtualserver_id' => '1',
+            'virtualserver_port' => '9987',
+            'virtualserver_status' => 'online',
+            'virtualserver_unique_identifier' => 'dwcJxlwg51mhDP1nlVQh51sIIzo=',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->httpClient
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->andReturn($response);
+
+    $result = $this->client->whoami();
+
+    expect($result)->toBeInstanceOf(WhoAmIResponse::class)
+        ->and($result->clientId)->toBe(14);
+});


### PR DESCRIPTION
## Summary

Closes #18

- Adds `Client::whoami()` returning `WhoAmIResponse` DTO
- `WhoAmIResponse` maps all session fields: `clientChannelId`, `clientDatabaseId`, `clientId`, `clientLoginName`, `clientNickname`, `clientOriginServerId`, `clientUniqueIdentifier`, `virtualServerId`, `virtualServerPort`, `virtualServerStatus`, `virtualServerUniqueIdentifier`
- Updates `ClientContract` with `whoami(): WhoAmIResponse`
- Updates COMMANDS.md with usage example

## Test plan

- [x] `composer test` passes (214 tests, 100% coverage, PHPStan max, type-coverage 100%)
- [x] `WhoAmITest` verifies request is sent and response is mapped correctly
- [x] `WhoAmIResponseTest` covers all DTO fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)