### PR TITLE
feat(permissions): implement global permission commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -598,27 +598,41 @@ $teamspeak->channelPermissions()->deleteForClient(channelId: 1, clientDatabaseId
 
 ## permissionlist
 
-Not implemented.
+```php
+$teamspeak->permissions()->list();
+```
 
 ## permidgetbyname
 
-Not implemented.
+```php
+$teamspeak->permissions()->getIdByName(name: 'b_serverinstance_help_view');
+```
 
 ## permoverview
 
-Not implemented.
+```php
+$teamspeak->permissions()->overview(channelId: 1, clientDatabaseId: 2);
+```
 
 ## permget
 
-Not implemented.
+```php
+$teamspeak->permissions()->get(id: 17835);
+$teamspeak->permissions()->get(id: 'b_serverinstance_help_view');
+```
 
 ## permfind
 
-Not implemented.
+```php
+$teamspeak->permissions()->find(id: 17835);
+$teamspeak->permissions()->find(id: 'b_serverinstance_help_view');
+```
 
 ## permreset
 
-Not implemented.
+```php
+$teamspeak->permissions()->reset();
+```
 
 ## privilegekeylist
 

--- a/src/Contracts/Resources/PermissionsContract.php
+++ b/src/Contracts/Resources/PermissionsContract.php
@@ -4,4 +4,48 @@ declare(strict_types=1);
 
 namespace TeamSpeak\WebQuery\Contracts\Resources;
 
-interface PermissionsContract {}
+use TeamSpeak\WebQuery\Responses\Permissions\FindResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\GetIdByNameResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\GetResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\ListResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\OverviewResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\ResetResponse;
+
+interface PermissionsContract
+{
+    /**
+     * Displays a list of all permissions available on the server.
+     */
+    public function list(): ListResponse;
+
+    /**
+     * Returns the ID of a permission specified by name.
+     */
+    public function getIdByName(string $name): GetIdByNameResponse;
+
+    /**
+     * Displays all permissions for a client in a specific channel.
+     */
+    public function overview(int $channelId, int $clientDatabaseId): OverviewResponse;
+
+    /**
+     * Displays the current value of a permission for the selected virtual server.
+     *
+     * A permission can be specified by ID or name.
+     */
+    public function get(string|int $id): GetResponse;
+
+    /**
+     * Displays all clients and groups assigned a specific permission.
+     *
+     * A permission can be specified by ID or name.
+     */
+    public function find(string|int $id): FindResponse;
+
+    /**
+     * Resets the permission settings of the virtual server to default values.
+     *
+     * Returns a new administrator privilege key.
+     */
+    public function reset(): ResetResponse;
+}

--- a/src/Resources/Permissions.php
+++ b/src/Resources/Permissions.php
@@ -5,8 +5,118 @@ declare(strict_types=1);
 namespace TeamSpeak\WebQuery\Resources;
 
 use TeamSpeak\WebQuery\Contracts\Resources\PermissionsContract;
+use TeamSpeak\WebQuery\Enums\Query\Command;
+use TeamSpeak\WebQuery\Responses\Permissions\FindResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\GetIdByNameResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\GetResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\ListResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\OverviewResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\ResetResponse;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Payload;
 
 final class Permissions implements PermissionsContract
 {
     use Concerns\Transportable;
+
+    /**
+     * Displays a list of all permissions available on the server.
+     */
+    public function list(): ListResponse
+    {
+        $payload = new Payload(Command::PermissionList);
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<list<array{permid: string, permname: string, permdesc: string, permtype: string, permisflag: string}>> $response */
+        $response = $this->transporter->request($payload);
+
+        return ListResponse::from($response->body());
+    }
+
+    /**
+     * Returns the ID of a permission specified by name.
+     */
+    public function getIdByName(string $name): GetIdByNameResponse
+    {
+        $payload = new Payload(
+            command: Command::PermIdGetByName,
+            parameters: ['permsid' => $name],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<array{0: array{permid: string, permsid: string}}> $response */
+        $response = $this->transporter->request($payload);
+
+        return GetIdByNameResponse::from($response->body());
+    }
+
+    /**
+     * Displays all permissions for a client in a specific channel.
+     */
+    public function overview(int $channelId, int $clientDatabaseId): OverviewResponse
+    {
+        $payload = new Payload(
+            command: Command::PermOverview,
+            parameters: ['cid' => $channelId, 'cldbid' => $clientDatabaseId],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<list<array{t: string, id1: string, id2: string, p: string, v: string, n: string, s: string}>> $response */
+        $response = $this->transporter->request($payload);
+
+        return OverviewResponse::from($response->body());
+    }
+
+    /**
+     * Displays the current value of a permission for the selected virtual server.
+     *
+     * A permission can be specified by ID or name.
+     */
+    public function get(string|int $id): GetResponse
+    {
+        $payload = new Payload(
+            command: Command::PermGet,
+            parameters: [
+                ...is_int($id) ? ['permid' => $id] : [],
+                ...is_string($id) ? ['permsid' => $id] : [],
+            ],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<array{0: array{permid: string, permsid: string, permvalue: string}}> $response */
+        $response = $this->transporter->request($payload);
+
+        return GetResponse::from($response->body());
+    }
+
+    /**
+     * Displays all clients and groups assigned a specific permission.
+     *
+     * A permission can be specified by ID or name.
+     */
+    public function find(string|int $id): FindResponse
+    {
+        $payload = new Payload(
+            command: Command::PermFind,
+            parameters: [
+                ...is_int($id) ? ['permid' => $id] : [],
+                ...is_string($id) ? ['permsid' => $id] : [],
+            ],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<list<array{t: string, id1: string, id2: string, p: string}>> $response */
+        $response = $this->transporter->request($payload);
+
+        return FindResponse::from($response->body());
+    }
+
+    /**
+     * Resets the permission settings of the virtual server to default values.
+     *
+     * Returns a new administrator privilege key.
+     */
+    public function reset(): ResetResponse
+    {
+        $payload = new Payload(Command::PermReset);
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<array{0: array{token: string}}> $response */
+        $response = $this->transporter->request($payload);
+
+        return ResetResponse::from($response->body());
+    }
 }

--- a/src/Responses/Permissions/FindResponse.php
+++ b/src/Responses/Permissions/FindResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class FindResponse
+{
+    /**
+     * @param  list<FindResponseAssignment>  $assignments
+     */
+    private function __construct(
+        public array $assignments,
+    ) {}
+
+    /**
+     * @param  list<array{t: string, id1: string, id2: string, p: string}>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            array_map(FindResponseAssignment::from(...), $attributes),
+        );
+    }
+}

--- a/src/Responses/Permissions/FindResponseAssignment.php
+++ b/src/Responses/Permissions/FindResponseAssignment.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class FindResponseAssignment
+{
+    private function __construct(
+        public int $type,
+        public int $id1,
+        public int $id2,
+        public int $permId,
+    ) {}
+
+    /**
+     * @param  array{t: string, id1: string, id2: string, p: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes['t'],
+            (int) $attributes['id1'],
+            (int) $attributes['id2'],
+            (int) $attributes['p'],
+        );
+    }
+}

--- a/src/Responses/Permissions/GetIdByNameResponse.php
+++ b/src/Responses/Permissions/GetIdByNameResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class GetIdByNameResponse
+{
+    private function __construct(
+        public int $id,
+        public string $name,
+    ) {}
+
+    /**
+     * @param  array{0: array{permid: string, permsid: string}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes[0]['permid'],
+            $attributes[0]['permsid'],
+        );
+    }
+}

--- a/src/Responses/Permissions/GetResponse.php
+++ b/src/Responses/Permissions/GetResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class GetResponse
+{
+    private function __construct(
+        public int $id,
+        public string $name,
+        public int $value,
+    ) {}
+
+    /**
+     * @param  array{0: array{permid: string, permsid: string, permvalue: string}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes[0]['permid'],
+            $attributes[0]['permsid'],
+            (int) $attributes[0]['permvalue'],
+        );
+    }
+}

--- a/src/Responses/Permissions/ListResponse.php
+++ b/src/Responses/Permissions/ListResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class ListResponse
+{
+    /**
+     * @param  list<ListResponsePermission>  $permissions
+     */
+    private function __construct(
+        public array $permissions,
+    ) {}
+
+    /**
+     * @param  list<array{permid: string, permname: string, permdesc: string, permtype: string, permisflag: string}>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            array_map(ListResponsePermission::from(...), $attributes),
+        );
+    }
+}

--- a/src/Responses/Permissions/ListResponsePermission.php
+++ b/src/Responses/Permissions/ListResponsePermission.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class ListResponsePermission
+{
+    private function __construct(
+        public int $id,
+        public string $name,
+        public string $description,
+        public int $type,
+        public bool $isFlag,
+    ) {}
+
+    /**
+     * @param  array{permid: string, permname: string, permdesc: string, permtype: string, permisflag: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes['permid'],
+            $attributes['permname'],
+            $attributes['permdesc'],
+            (int) $attributes['permtype'],
+            (bool) $attributes['permisflag'],
+        );
+    }
+}

--- a/src/Responses/Permissions/OverviewResponse.php
+++ b/src/Responses/Permissions/OverviewResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class OverviewResponse
+{
+    /**
+     * @param  list<OverviewResponsePermission>  $permissions
+     */
+    private function __construct(
+        public array $permissions,
+    ) {}
+
+    /**
+     * @param  list<array{t: string, id1: string, id2: string, p: string, v: string, n: string, s: string}>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            array_map(OverviewResponsePermission::from(...), $attributes),
+        );
+    }
+}

--- a/src/Responses/Permissions/OverviewResponsePermission.php
+++ b/src/Responses/Permissions/OverviewResponsePermission.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class OverviewResponsePermission
+{
+    private function __construct(
+        public int $type,
+        public int $id1,
+        public int $id2,
+        public int $permId,
+        public int $value,
+        public bool $negated,
+        public bool $skip,
+    ) {}
+
+    /**
+     * @param  array{t: string, id1: string, id2: string, p: string, v: string, n: string, s: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes['t'],
+            (int) $attributes['id1'],
+            (int) $attributes['id2'],
+            (int) $attributes['p'],
+            (int) $attributes['v'],
+            (bool) $attributes['n'],
+            (bool) $attributes['s'],
+        );
+    }
+}

--- a/src/Responses/Permissions/ResetResponse.php
+++ b/src/Responses/Permissions/ResetResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Permissions;
+
+final readonly class ResetResponse
+{
+    private function __construct(
+        public string $token,
+    ) {}
+
+    /**
+     * @param  array{0: array{token: string}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes[0]['token'],
+        );
+    }
+}

--- a/tests/Unit/Resources/PermissionsTest.php
+++ b/tests/Unit/Resources/PermissionsTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use TeamSpeak\WebQuery\Resources\Permissions;
+use TeamSpeak\WebQuery\Transporters\HttpTransporter;
+use TeamSpeak\WebQuery\ValueObjects\ApiKey;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\BaseUri;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Headers;
+
+beforeEach(function () {
+    $this->client = Mockery::mock(ClientInterface::class);
+
+    $apiKey = ApiKey::from('foo');
+
+    $this->http = new HttpTransporter(
+        $this->client,
+        BaseUri::from('teamspeak.com'),
+        Headers::withXApiKey($apiKey),
+    );
+});
+
+test('list', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'permid' => '1',
+            'permname' => 'b_serverinstance_help_view',
+            'permdesc' => 'Retrieve information about the server instance',
+            'permtype' => '0',
+            'permisflag' => '1',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBe('');
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->list()->permissions)->toBeArray()->toHaveCount(1);
+});
+
+test('get id by name', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'permid' => '1',
+            'permsid' => 'b_serverinstance_help_view',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['permsid' => 'b_serverinstance_help_view']);
+
+            return true;
+        })->andReturn($response);
+
+    $result = $resource->getIdByName('b_serverinstance_help_view');
+    expect($result->id)->toBe(1)
+        ->and($result->name)->toBe('b_serverinstance_help_view');
+});
+
+test('overview', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            't' => '0',
+            'id1' => '0',
+            'id2' => '0',
+            'p' => '17',
+            'v' => '1',
+            'n' => '0',
+            's' => '0',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['cid' => '1', 'cldbid' => '2']);
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->overview(1, 2)->permissions)->toBeArray()->toHaveCount(1);
+});
+
+test('get by ID', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'permid' => '17835',
+            'permsid' => 'b_serverinstance_help_view',
+            'permvalue' => '1',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['permid' => '17835']);
+
+            return true;
+        })->andReturn($response);
+
+    $result = $resource->get(17835);
+    expect($result->id)->toBe(17835)
+        ->and($result->value)->toBe(1);
+});
+
+test('get by name', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'permid' => '17835',
+            'permsid' => 'b_serverinstance_help_view',
+            'permvalue' => '1',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['permsid' => 'b_serverinstance_help_view']);
+
+            return true;
+        })->andReturn($response);
+
+    $result = $resource->get('b_serverinstance_help_view');
+    expect($result->name)->toBe('b_serverinstance_help_view');
+});
+
+test('find by ID', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            't' => '0',
+            'id1' => '0',
+            'id2' => '0',
+            'p' => '17835',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['permid' => '17835']);
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->find(17835)->assignments)->toHaveCount(1);
+});
+
+test('find by name', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            't' => '0',
+            'id1' => '0',
+            'id2' => '0',
+            'p' => '17835',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['permsid' => 'b_serverinstance_help_view']);
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->find('b_serverinstance_help_view')->assignments)->toHaveCount(1);
+});
+
+test('reset', function () {
+    $resource = new Permissions($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'token' => 'eKnFZQ9EK7G7EmPvt1Ch7vsXi5Uq+1Us7xrQKBVsMxM=',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBe('');
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->reset()->token)->toBe('eKnFZQ9EK7G7EmPvt1Ch7vsXi5Uq+1Us7xrQKBVsMxM=');
+});

--- a/tests/Unit/Responses/Permissions/FindResponseAssignmentTest.php
+++ b/tests/Unit/Responses/Permissions/FindResponseAssignmentTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\FindResponseAssignment;
+
+test('from', function () {
+    $assignment = FindResponseAssignment::from([
+        't' => '2',
+        'id1' => '6',
+        'id2' => '3',
+        'p' => '17835',
+    ]);
+
+    expect($assignment->type)->toBe(2)
+        ->and($assignment->id1)->toBe(6)
+        ->and($assignment->id2)->toBe(3)
+        ->and($assignment->permId)->toBe(17835);
+});

--- a/tests/Unit/Responses/Permissions/FindResponseTest.php
+++ b/tests/Unit/Responses/Permissions/FindResponseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\FindResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\FindResponseAssignment;
+
+test('from', function () {
+    $response = FindResponse::from([[
+        't' => '0',
+        'id1' => '0',
+        'id2' => '0',
+        'p' => '17835',
+    ]]);
+
+    expect($response->assignments)->toHaveCount(1)
+        ->and($response->assignments[0])->toBeInstanceOf(FindResponseAssignment::class);
+});

--- a/tests/Unit/Responses/Permissions/GetIdByNameResponseTest.php
+++ b/tests/Unit/Responses/Permissions/GetIdByNameResponseTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\GetIdByNameResponse;
+
+test('from', function () {
+    $response = GetIdByNameResponse::from([[
+        'permid' => '17835',
+        'permsid' => 'b_serverinstance_help_view',
+    ]]);
+
+    expect($response->id)->toBe(17835)
+        ->and($response->name)->toBe('b_serverinstance_help_view');
+});

--- a/tests/Unit/Responses/Permissions/GetResponseTest.php
+++ b/tests/Unit/Responses/Permissions/GetResponseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\GetResponse;
+
+test('from', function () {
+    $response = GetResponse::from([[
+        'permid' => '17835',
+        'permsid' => 'b_serverinstance_help_view',
+        'permvalue' => '1',
+    ]]);
+
+    expect($response->id)->toBe(17835)
+        ->and($response->name)->toBe('b_serverinstance_help_view')
+        ->and($response->value)->toBe(1);
+});

--- a/tests/Unit/Responses/Permissions/ListResponsePermissionTest.php
+++ b/tests/Unit/Responses/Permissions/ListResponsePermissionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\ListResponsePermission;
+
+test('from', function () {
+    $permission = ListResponsePermission::from([
+        'permid' => '1',
+        'permname' => 'b_serverinstance_help_view',
+        'permdesc' => 'Retrieve information about the server instance',
+        'permtype' => '0',
+        'permisflag' => '1',
+    ]);
+
+    expect($permission->id)->toBe(1)
+        ->and($permission->name)->toBe('b_serverinstance_help_view')
+        ->and($permission->description)->toBe('Retrieve information about the server instance')
+        ->and($permission->type)->toBe(0)
+        ->and($permission->isFlag)->toBeTrue();
+});

--- a/tests/Unit/Responses/Permissions/ListResponseTest.php
+++ b/tests/Unit/Responses/Permissions/ListResponseTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\ListResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\ListResponsePermission;
+
+test('from', function () {
+    $response = ListResponse::from([[
+        'permid' => '1',
+        'permname' => 'b_serverinstance_help_view',
+        'permdesc' => 'Retrieve information about the server instance',
+        'permtype' => '0',
+        'permisflag' => '1',
+    ]]);
+
+    expect($response->permissions)->toHaveCount(1)
+        ->and($response->permissions[0])->toBeInstanceOf(ListResponsePermission::class);
+});

--- a/tests/Unit/Responses/Permissions/OverviewResponsePermissionTest.php
+++ b/tests/Unit/Responses/Permissions/OverviewResponsePermissionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\OverviewResponsePermission;
+
+test('from', function () {
+    $permission = OverviewResponsePermission::from([
+        't' => '1',
+        'id1' => '5',
+        'id2' => '3',
+        'p' => '17',
+        'v' => '75',
+        'n' => '1',
+        's' => '0',
+    ]);
+
+    expect($permission->type)->toBe(1)
+        ->and($permission->id1)->toBe(5)
+        ->and($permission->id2)->toBe(3)
+        ->and($permission->permId)->toBe(17)
+        ->and($permission->value)->toBe(75)
+        ->and($permission->negated)->toBeTrue()
+        ->and($permission->skip)->toBeFalse();
+});

--- a/tests/Unit/Responses/Permissions/OverviewResponseTest.php
+++ b/tests/Unit/Responses/Permissions/OverviewResponseTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\OverviewResponse;
+use TeamSpeak\WebQuery\Responses\Permissions\OverviewResponsePermission;
+
+test('from', function () {
+    $response = OverviewResponse::from([[
+        't' => '0',
+        'id1' => '5',
+        'id2' => '0',
+        'p' => '17',
+        'v' => '75',
+        'n' => '0',
+        's' => '1',
+    ]]);
+
+    expect($response->permissions)->toHaveCount(1)
+        ->and($response->permissions[0])->toBeInstanceOf(OverviewResponsePermission::class);
+});

--- a/tests/Unit/Responses/Permissions/ResetResponseTest.php
+++ b/tests/Unit/Responses/Permissions/ResetResponseTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Permissions\ResetResponse;
+
+test('from', function () {
+    $response = ResetResponse::from([[
+        'token' => 'eKnFZQ9EK7G7EmPvt1Ch7vsXi5Uq+1Us7xrQKBVsMxM=',
+    ]]);
+
+    expect($response->token)->toBe('eKnFZQ9EK7G7EmPvt1Ch7vsXi5Uq+1Us7xrQKBVsMxM=');
+});


### PR DESCRIPTION
Closes #13

## Summary

- Implements `permissionlist`, `permidgetbyname`, `permoverview`, `permget`, `permfind`, `permreset`
- 9 response DTOs under `src/Responses/Permissions/`
- 8 resource tests + 9 DTO tests (100% coverage maintained)
- COMMANDS.md updated with PHP usage examples

## API

```php
$teamspeak->permissions()->list();
$teamspeak->permissions()->getIdByName(name: 'b_serverinstance_help_view');
$teamspeak->permissions()->overview(channelId: 1, clientDatabaseId: 2);
$teamspeak->permissions()->get(id: 17835);
$teamspeak->permissions()->get(id: 'b_serverinstance_help_view');
$teamspeak->permissions()->find(id: 17835);
$teamspeak->permissions()->find(id: 'b_serverinstance_help_view');
$teamspeak->permissions()->reset();
```

## Test plan

- [x] `composer test` passes (Rector, Pint, PHPStan max, 100% type coverage, 100% code coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)