### PR TITLE
feat(servers): implement server snapshot commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -223,11 +223,17 @@ Not implemented.
 
 ## serversnapshotcreate
 
-Not implemented.
+```php
+$snapshot = $teamspeak->servers()->createSnapshot();
+// $snapshot->hash — MD5 hash of the snapshot
+// $snapshot->data — snapshot data to pass to deploySnapshot
+```
 
 ## serversnapshotdeploy
 
-Not implemented.
+```php
+$teamspeak->servers()->deploySnapshot(snapshot: $snapshot->data);
+```
 
 ## sendtextmessage
 

--- a/src/Contracts/Resources/ServersContract.php
+++ b/src/Contracts/Resources/ServersContract.php
@@ -7,6 +7,7 @@ namespace TeamSpeak\WebQuery\Contracts\Resources;
 use TeamSpeak\WebQuery\Responses\Servers\BindingListResponse;
 use TeamSpeak\WebQuery\Responses\Servers\ConnectionInfoResponse;
 use TeamSpeak\WebQuery\Responses\Servers\CreateResponse;
+use TeamSpeak\WebQuery\Responses\Servers\CreateSnapshotResponse;
 use TeamSpeak\WebQuery\Responses\Servers\HostInfoResponse;
 use TeamSpeak\WebQuery\Responses\Servers\IdGetByPortResponse;
 use TeamSpeak\WebQuery\Responses\Servers\InfoResponse;
@@ -114,4 +115,16 @@ interface ServersContract
      * @param  array<string, string|int|bool|null>  $properties
      */
     public function edit(array $properties): void;
+
+    /**
+     * Creates a snapshot of the selected virtual server.
+     *
+     * Returns the snapshot hash and data which can be used with deploySnapshot.
+     */
+    public function createSnapshot(): CreateSnapshotResponse;
+
+    /**
+     * Deploys a previously created virtual server snapshot.
+     */
+    public function deploySnapshot(string $snapshot): void;
 }

--- a/src/Resources/Servers.php
+++ b/src/Resources/Servers.php
@@ -9,6 +9,7 @@ use TeamSpeak\WebQuery\Enums\Query\Command;
 use TeamSpeak\WebQuery\Responses\Servers\BindingListResponse;
 use TeamSpeak\WebQuery\Responses\Servers\ConnectionInfoResponse;
 use TeamSpeak\WebQuery\Responses\Servers\CreateResponse;
+use TeamSpeak\WebQuery\Responses\Servers\CreateSnapshotResponse;
 use TeamSpeak\WebQuery\Responses\Servers\HostInfoResponse;
 use TeamSpeak\WebQuery\Responses\Servers\IdGetByPortResponse;
 use TeamSpeak\WebQuery\Responses\Servers\InfoResponse;
@@ -283,6 +284,34 @@ final class Servers implements ServersContract
         $payload = new Payload(
             command: Command::ServerEdit,
             parameters: $properties,
+        );
+
+        $this->transporter->request($payload);
+    }
+
+    /**
+     * Creates a snapshot of the selected virtual server.
+     *
+     * Returns the snapshot hash and data which can be used with deploySnapshot.
+     */
+    public function createSnapshot(): CreateSnapshotResponse
+    {
+        $payload = new Payload(Command::ServerSnapshotCreate);
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<array{0: array{hash: string, virtualserver_snapshot: string}}> $response */
+        $response = $this->transporter->request($payload);
+
+        return CreateSnapshotResponse::from($response->body());
+    }
+
+    /**
+     * Deploys a previously created virtual server snapshot.
+     */
+    public function deploySnapshot(string $snapshot): void
+    {
+        $payload = new Payload(
+            command: Command::ServerSnapshotDeploy,
+            parameters: ['virtualserver_snapshot' => $snapshot],
         );
 
         $this->transporter->request($payload);

--- a/src/Responses/Servers/CreateSnapshotResponse.php
+++ b/src/Responses/Servers/CreateSnapshotResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\Servers;
+
+final readonly class CreateSnapshotResponse
+{
+    private function __construct(
+        public string $hash,
+        public string $data,
+    ) {}
+
+    /**
+     * @param  array{0: array{hash: string, virtualserver_snapshot: string}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes[0]['hash'],
+            $attributes[0]['virtualserver_snapshot'],
+        );
+    }
+}

--- a/tests/Unit/Resources/ServersTest.php
+++ b/tests/Unit/Resources/ServersTest.php
@@ -526,3 +526,49 @@ test('edit', function () {
 
     $resource->edit(['virtualserver_name' => 'New Name']);
 })->doesNotPerformAssertions();
+
+test('create snapshot', function () {
+    $resource = new Servers($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'hash' => 'abc123',
+            'virtualserver_snapshot' => 'base64encodedsnapshotdata==',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBe('');
+
+            return true;
+        })->andReturn($response);
+
+    $result = $resource->createSnapshot();
+    expect($result->hash)->toBe('abc123')
+        ->and($result->data)->toBe('base64encodedsnapshotdata==');
+});
+
+test('deploy snapshot', function () {
+    $resource = new Servers($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['virtualserver_snapshot' => 'base64encodedsnapshotdata==']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->deploySnapshot('base64encodedsnapshotdata==');
+})->doesNotPerformAssertions();

--- a/tests/Unit/Responses/Servers/CreateSnapshotResponseTest.php
+++ b/tests/Unit/Responses/Servers/CreateSnapshotResponseTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\Servers\CreateSnapshotResponse;
+
+test('from', function () {
+    $response = CreateSnapshotResponse::from([[
+        'hash' => 'abc123',
+        'virtualserver_snapshot' => 'base64encodedsnapshotdata==',
+    ]]);
+
+    expect($response->hash)->toBe('abc123')
+        ->and($response->data)->toBe('base64encodedsnapshotdata==');
+});


### PR DESCRIPTION
Closes #16

## Summary

- Adds `createSnapshot()` and `deploySnapshot()` to the existing `Servers` resource
- `CreateSnapshotResponse` DTO with `hash` and `data` fields
- 2 resource tests, 1 DTO test (100% coverage maintained)
- COMMANDS.md updated

## API

```php
$snapshot = $teamspeak->servers()->createSnapshot();
$teamspeak->servers()->deploySnapshot(snapshot: $snapshot->data);
```

## Test plan

- [x] `composer test` passes (Rector, Pint, PHPStan max, 100% type coverage, 100% code coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)