### PR TITLE
feat(server-groups): implement server group auto-permission commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -215,11 +215,17 @@ $teamspeak->serverGroups()->getByClient(clientDatabaseId: 18);
 
 ## servergroupautoaddperm
 
-Not implemented.
+```php
+$teamspeak->serverGroups()->addAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 17835, value: 75);
+$teamspeak->serverGroups()->addAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 'b_serverinstance_help_view', value: 75, negated: true, skip: true);
+```
 
 ## servergroupautodelperm
 
-Not implemented.
+```php
+$teamspeak->serverGroups()->deleteAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 17835);
+$teamspeak->serverGroups()->deleteAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 'b_serverinstance_help_view');
+```
 
 ## serversnapshotcreate
 

--- a/src/Contracts/Resources/ServerGroupsContract.php
+++ b/src/Contracts/Resources/ServerGroupsContract.php
@@ -117,4 +117,14 @@ interface ServerGroupsContract
      * Displays all server groups the client is currently residing in.
      */
     public function getByClient(int $clientDatabaseId): GetByClientResponse;
+
+    /**
+     * Adds a permission to all server groups of the specified type.
+     */
+    public function addAutoPermission(PermissionGroupDatabaseTypes $type, string|int $id, int $value, bool $negated = false, bool $skip = false): void;
+
+    /**
+     * Removes a permission from all server groups of the specified type.
+     */
+    public function deleteAutoPermission(PermissionGroupDatabaseTypes $type, string|int $id): void;
 }

--- a/src/Resources/ServerGroups.php
+++ b/src/Resources/ServerGroups.php
@@ -261,4 +261,41 @@ final class ServerGroups implements ServerGroupsContract
 
         return GetByClientResponse::from($response->body());
     }
+
+    /**
+     * Adds a permission to all server groups of the specified type.
+     */
+    public function addAutoPermission(PermissionGroupDatabaseTypes $type, string|int $id, int $value, bool $negated = false, bool $skip = false): void
+    {
+        $payload = new Payload(
+            command: Command::ServerGroupAutoAddPerm,
+            parameters: [
+                'sgtype' => $type->value,
+                ...is_int($id) ? ['permid' => $id] : [],
+                ...is_string($id) ? ['permsid' => $id] : [],
+                'permvalue' => $value,
+                'permnegated' => $negated,
+                'permskip' => $skip,
+            ],
+        );
+
+        $this->transporter->request($payload);
+    }
+
+    /**
+     * Removes a permission from all server groups of the specified type.
+     */
+    public function deleteAutoPermission(PermissionGroupDatabaseTypes $type, string|int $id): void
+    {
+        $payload = new Payload(
+            command: Command::ServerGroupAutoDelPerm,
+            parameters: [
+                'sgtype' => $type->value,
+                ...is_int($id) ? ['permid' => $id] : [],
+                ...is_string($id) ? ['permsid' => $id] : [],
+            ],
+        );
+
+        $this->transporter->request($payload);
+    }
 }

--- a/tests/Unit/Resources/ServerGroupsTest.php
+++ b/tests/Unit/Resources/ServerGroupsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Client\ClientInterface;
+use TeamSpeak\WebQuery\Enums\PermissionGroupDatabaseTypes;
 use TeamSpeak\WebQuery\Resources\ServerGroups;
 use TeamSpeak\WebQuery\Transporters\HttpTransporter;
 use TeamSpeak\WebQuery\ValueObjects\ApiKey;
@@ -525,3 +526,87 @@ test('get by client', function () {
 
     $resource->getByClient(18);
 });
+
+test('add auto permission by ID', function () {
+    $resource = new ServerGroups($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['sgtype' => '1', 'permid' => '17835', 'permvalue' => '75', 'permnegated' => '0', 'permskip' => '0']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->addAutoPermission(PermissionGroupDatabaseTypes::Regular, 17835, 75);
+})->doesNotPerformAssertions();
+
+test('add auto permission by name', function () {
+    $resource = new ServerGroups($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['sgtype' => '1', 'permsid' => 'b_serverinstance_help_view', 'permvalue' => '75', 'permnegated' => '1', 'permskip' => '1']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->addAutoPermission(PermissionGroupDatabaseTypes::Regular, 'b_serverinstance_help_view', 75, true, true);
+})->doesNotPerformAssertions();
+
+test('delete auto permission by ID', function () {
+    $resource = new ServerGroups($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['sgtype' => '1', 'permid' => '17835']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->deleteAutoPermission(PermissionGroupDatabaseTypes::Regular, 17835);
+})->doesNotPerformAssertions();
+
+test('delete auto permission by name', function () {
+    $resource = new ServerGroups($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['sgtype' => '1', 'permsid' => 'b_serverinstance_help_view']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->deleteAutoPermission(PermissionGroupDatabaseTypes::Regular, 'b_serverinstance_help_view');
+})->doesNotPerformAssertions();


### PR DESCRIPTION
Closes #15

## Summary

- Adds `addAutoPermission()` and `deleteAutoPermission()` to `ServerGroups` resource
- Both accept `PermissionGroupDatabaseTypes` enum for the group type
- Permission can be specified by ID (int) or name (string)
- 4 tests added (100% coverage maintained)
- COMMANDS.md updated

## API

```php
$teamspeak->serverGroups()->addAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 17835, value: 75);
$teamspeak->serverGroups()->addAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 'b_serverinstance_help_view', value: 75, negated: true);
$teamspeak->serverGroups()->deleteAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 17835);
$teamspeak->serverGroups()->deleteAutoPermission(type: PermissionGroupDatabaseTypes::Regular, id: 'b_serverinstance_help_view');
```

## Test plan

- [x] `composer test` passes (Rector, Pint, PHPStan max, 100% type coverage, 100% code coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)