### PR TITLE
feat(custom-properties): implement custom properties commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -767,11 +767,15 @@ $teamspeak->bans()->deleteAll();
 
 ## customsearch
 
-Not implemented.
+```php
+$teamspeak->customProperties()->search(ident: 'forum_id', pattern: '12345');
+```
 
 ## custominfo
 
-Not implemented.
+```php
+$teamspeak->customProperties()->info(clientDatabaseId: 18);
+```
 
 ## whoami
 

--- a/src/Contracts/Resources/CustomPropertiesContract.php
+++ b/src/Contracts/Resources/CustomPropertiesContract.php
@@ -4,4 +4,18 @@ declare(strict_types=1);
 
 namespace TeamSpeak\WebQuery\Contracts\Resources;
 
-interface CustomPropertiesContract {}
+use TeamSpeak\WebQuery\Responses\CustomProperties\InfoResponse;
+use TeamSpeak\WebQuery\Responses\CustomProperties\SearchResponse;
+
+interface CustomPropertiesContract
+{
+    /**
+     * Searches for clients with a custom property matching the given ident and pattern.
+     */
+    public function search(string $ident, string $pattern): SearchResponse;
+
+    /**
+     * Displays all custom properties for the client with the given database ID.
+     */
+    public function info(int $clientDatabaseId): InfoResponse;
+}

--- a/src/Resources/CustomProperties.php
+++ b/src/Resources/CustomProperties.php
@@ -5,8 +5,44 @@ declare(strict_types=1);
 namespace TeamSpeak\WebQuery\Resources;
 
 use TeamSpeak\WebQuery\Contracts\Resources\CustomPropertiesContract;
+use TeamSpeak\WebQuery\Enums\Query\Command;
+use TeamSpeak\WebQuery\Responses\CustomProperties\InfoResponse;
+use TeamSpeak\WebQuery\Responses\CustomProperties\SearchResponse;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Payload;
 
 final class CustomProperties implements CustomPropertiesContract
 {
     use Concerns\Transportable;
+
+    /**
+     * Searches for clients with a custom property matching the given ident and pattern.
+     */
+    public function search(string $ident, string $pattern): SearchResponse
+    {
+        $payload = new Payload(
+            command: Command::CustomSearch,
+            parameters: ['ident' => $ident, 'pattern' => $pattern],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<list<array{cldbid: string, ident: string, value: string}>> $response */
+        $response = $this->transporter->request($payload);
+
+        return SearchResponse::from($response->body());
+    }
+
+    /**
+     * Displays all custom properties for the client with the given database ID.
+     */
+    public function info(int $clientDatabaseId): InfoResponse
+    {
+        $payload = new Payload(
+            command: Command::CustomInfo,
+            parameters: ['cldbid' => $clientDatabaseId],
+        );
+
+        /** @var \TeamSpeak\WebQuery\ValueObjects\Transporter\Response<list<array{cldbid: string, ident: string, value: string}>> $response */
+        $response = $this->transporter->request($payload);
+
+        return InfoResponse::from($response->body());
+    }
 }

--- a/src/Responses/CustomProperties/InfoResponse.php
+++ b/src/Responses/CustomProperties/InfoResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\CustomProperties;
+
+final readonly class InfoResponse
+{
+    /**
+     * @param  list<InfoResponseProperty>  $properties
+     */
+    private function __construct(
+        public array $properties,
+    ) {}
+
+    /**
+     * @param  list<array{cldbid: string, ident: string, value: string}>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            array_map(InfoResponseProperty::from(...), $attributes),
+        );
+    }
+}

--- a/src/Responses/CustomProperties/InfoResponseProperty.php
+++ b/src/Responses/CustomProperties/InfoResponseProperty.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\CustomProperties;
+
+final readonly class InfoResponseProperty
+{
+    private function __construct(
+        public int $clientDatabaseId,
+        public string $ident,
+        public string $value,
+    ) {}
+
+    /**
+     * @param  array{cldbid: string, ident: string, value: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes['cldbid'],
+            $attributes['ident'],
+            $attributes['value'],
+        );
+    }
+}

--- a/src/Responses/CustomProperties/SearchResponse.php
+++ b/src/Responses/CustomProperties/SearchResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\CustomProperties;
+
+final readonly class SearchResponse
+{
+    /**
+     * @param  list<SearchResponseResult>  $results
+     */
+    private function __construct(
+        public array $results,
+    ) {}
+
+    /**
+     * @param  list<array{cldbid: string, ident: string, value: string}>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            array_map(SearchResponseResult::from(...), $attributes),
+        );
+    }
+}

--- a/src/Responses/CustomProperties/SearchResponseResult.php
+++ b/src/Responses/CustomProperties/SearchResponseResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TeamSpeak\WebQuery\Responses\CustomProperties;
+
+final readonly class SearchResponseResult
+{
+    private function __construct(
+        public int $clientDatabaseId,
+        public string $ident,
+        public string $value,
+    ) {}
+
+    /**
+     * @param  array{cldbid: string, ident: string, value: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            (int) $attributes['cldbid'],
+            $attributes['ident'],
+            $attributes['value'],
+        );
+    }
+}

--- a/tests/Unit/Resources/CustomPropertiesTest.php
+++ b/tests/Unit/Resources/CustomPropertiesTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use TeamSpeak\WebQuery\Resources\CustomProperties;
+use TeamSpeak\WebQuery\Transporters\HttpTransporter;
+use TeamSpeak\WebQuery\ValueObjects\ApiKey;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\BaseUri;
+use TeamSpeak\WebQuery\ValueObjects\Transporter\Headers;
+
+beforeEach(function () {
+    $this->client = Mockery::mock(ClientInterface::class);
+
+    $apiKey = ApiKey::from('foo');
+
+    $this->http = new HttpTransporter(
+        $this->client,
+        BaseUri::from('teamspeak.com'),
+        Headers::withXApiKey($apiKey),
+    );
+});
+
+test('search', function () {
+    $resource = new CustomProperties($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'cldbid' => '18',
+            'ident' => 'forum_id',
+            'value' => '12345',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['ident' => 'forum_id', 'pattern' => '12345']);
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->search('forum_id', '12345')->results)->toBeArray()->toHaveCount(1);
+});
+
+test('info', function () {
+    $resource = new CustomProperties($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'body' => [[
+            'cldbid' => '18',
+            'ident' => 'forum_id',
+            'value' => '12345',
+        ]],
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['cldbid' => '18']);
+
+            return true;
+        })->andReturn($response);
+
+    expect($resource->info(18)->properties)->toBeArray()->toHaveCount(1);
+});

--- a/tests/Unit/Responses/CustomProperties/InfoResponsePropertyTest.php
+++ b/tests/Unit/Responses/CustomProperties/InfoResponsePropertyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\CustomProperties\InfoResponseProperty;
+
+test('from', function () {
+    $property = InfoResponseProperty::from([
+        'cldbid' => '18',
+        'ident' => 'forum_id',
+        'value' => '12345',
+    ]);
+
+    expect($property->clientDatabaseId)->toBe(18)
+        ->and($property->ident)->toBe('forum_id')
+        ->and($property->value)->toBe('12345');
+});

--- a/tests/Unit/Responses/CustomProperties/InfoResponseTest.php
+++ b/tests/Unit/Responses/CustomProperties/InfoResponseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\CustomProperties\InfoResponse;
+use TeamSpeak\WebQuery\Responses\CustomProperties\InfoResponseProperty;
+
+test('from', function () {
+    $response = InfoResponse::from([[
+        'cldbid' => '18',
+        'ident' => 'forum_id',
+        'value' => '12345',
+    ]]);
+
+    expect($response->properties)->toHaveCount(1)
+        ->and($response->properties[0])->toBeInstanceOf(InfoResponseProperty::class);
+});

--- a/tests/Unit/Responses/CustomProperties/SearchResponseResultTest.php
+++ b/tests/Unit/Responses/CustomProperties/SearchResponseResultTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\CustomProperties\SearchResponseResult;
+
+test('from', function () {
+    $result = SearchResponseResult::from([
+        'cldbid' => '18',
+        'ident' => 'forum_id',
+        'value' => '12345',
+    ]);
+
+    expect($result->clientDatabaseId)->toBe(18)
+        ->and($result->ident)->toBe('forum_id')
+        ->and($result->value)->toBe('12345');
+});

--- a/tests/Unit/Responses/CustomProperties/SearchResponseTest.php
+++ b/tests/Unit/Responses/CustomProperties/SearchResponseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use TeamSpeak\WebQuery\Responses\CustomProperties\SearchResponse;
+use TeamSpeak\WebQuery\Responses\CustomProperties\SearchResponseResult;
+
+test('from', function () {
+    $response = SearchResponse::from([[
+        'cldbid' => '18',
+        'ident' => 'forum_id',
+        'value' => '12345',
+    ]]);
+
+    expect($response->results)->toHaveCount(1)
+        ->and($response->results[0])->toBeInstanceOf(SearchResponseResult::class);
+});


### PR DESCRIPTION
Closes #17

## Summary

- Implements `customsearch` and `custominfo` in `CustomProperties` resource
- 4 response DTOs: `SearchResponse`, `SearchResponseResult`, `InfoResponse`, `InfoResponseProperty`
- 2 resource tests + 4 DTO tests (100% coverage maintained)
- COMMANDS.md updated

## API

```php
$teamspeak->customProperties()->search(ident: 'forum_id', pattern: '12345');
$teamspeak->customProperties()->info(clientDatabaseId: 18);
```

## Test plan

- [x] `composer test` passes (Rector, Pint, PHPStan max, 100% type coverage, 100% code coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)