### PR TITLE
feat(logs): add log level shortcut methods

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -271,6 +271,11 @@ $teamspeak->logs()->list(lines: 50, reverse: true, instance: true, beginPos: 100
 use TeamSpeak\WebQuery\Enums\LogLevel;
 
 $teamspeak->logs()->add(LogLevel::Info, 'custom log message');
+// also available shortcuts:
+$teamspeak->logs()->error('something failed');
+$teamspeak->logs()->warning('something suspicious');
+$teamspeak->logs()->debug('debug info');
+$teamspeak->logs()->info('server started');
 ```
 
 ## gm

--- a/src/Contracts/Resources/LogsContract.php
+++ b/src/Contracts/Resources/LogsContract.php
@@ -18,4 +18,24 @@ interface LogsContract
      * Writes a custom entry into the server log.
      */
     public function add(LogLevel $level, string $message): void;
+
+    /**
+     * Writes an error entry into the server log.
+     */
+    public function error(string $message): void;
+
+    /**
+     * Writes a warning entry into the server log.
+     */
+    public function warning(string $message): void;
+
+    /**
+     * Writes a debug entry into the server log.
+     */
+    public function debug(string $message): void;
+
+    /**
+     * Writes an info entry into the server log.
+     */
+    public function info(string $message): void;
 }

--- a/src/Resources/Logs.php
+++ b/src/Resources/Logs.php
@@ -42,4 +42,36 @@ final class Logs implements LogsContract
 
         $this->transporter->request($payload);
     }
+
+    /**
+     * Writes an error entry into the server log.
+     */
+    public function error(string $message): void
+    {
+        $this->add(LogLevel::Error, $message);
+    }
+
+    /**
+     * Writes a warning entry into the server log.
+     */
+    public function warning(string $message): void
+    {
+        $this->add(LogLevel::Warning, $message);
+    }
+
+    /**
+     * Writes a debug entry into the server log.
+     */
+    public function debug(string $message): void
+    {
+        $this->add(LogLevel::Debug, $message);
+    }
+
+    /**
+     * Writes an info entry into the server log.
+     */
+    public function info(string $message): void
+    {
+        $this->add(LogLevel::Info, $message);
+    }
 }

--- a/tests/Unit/Resources/LogsTest.php
+++ b/tests/Unit/Resources/LogsTest.php
@@ -106,3 +106,87 @@ test('add', function () {
 
     $resource->add(LogLevel::Info, 'test message');
 })->doesNotPerformAssertions();
+
+test('error shortcut', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['loglevel' => '1', 'logmsg' => 'something failed']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->error('something failed');
+})->doesNotPerformAssertions();
+
+test('warning shortcut', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['loglevel' => '2', 'logmsg' => 'something suspicious']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->warning('something suspicious');
+})->doesNotPerformAssertions();
+
+test('debug shortcut', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['loglevel' => '3', 'logmsg' => 'debug info']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->debug('debug info');
+})->doesNotPerformAssertions();
+
+test('info shortcut', function () {
+    $resource = new Logs($this->http);
+
+    $response = new Response(200, ['Content-Type' => 'application/json'], json_encode([
+        'status' => ['code' => 0, 'message' => 'ok'],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->withArgs(function (Psr7Request $request) {
+            expect($request->getBody()->getContents())->toBeJson()
+                ->json()
+                ->toBe(['loglevel' => '4', 'logmsg' => 'server started']);
+
+            return true;
+        })->andReturn($response);
+
+    $resource->info('server started');
+})->doesNotPerformAssertions();


### PR DESCRIPTION
## Summary
- Add `error()`, `warning()`, `debug()`, `info()` shortcut methods to `Logs` resource and `LogsContract`
- Each shortcut delegates to `add()` with the corresponding `LogLevel` enum value
- Update `COMMANDS.md` with shortcut examples

## Test plan
- [ ] All shortcut methods covered by unit tests
- [ ] `composer test` passes (PHPStan max, 100% type coverage, 100% code coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)